### PR TITLE
Support for CSJX to javascript using coffee-react

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'maven'
 
 group = 'net.errbuddy.plugins'
-version = '2.0.0'
+version = '2.0.1-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 buildscript {
@@ -36,6 +36,7 @@ sourceSets {
 dependencies {
     provided 'org.codehaus.groovy:groovy-all:2.0.7'
     compile "com.bertramlabs.plugins:asset-pipeline-core:2.1.1"
+    compile "com.bertramlabs.plugins:coffee-asset-pipeline:2.0.7"
     compile 'org.mozilla:rhino:1.7R4'
     compile 'log4j:log4j:1.2.17'
 

--- a/src/main/groovy/asset/pipeline/react/CjsxAssetFile.groovy
+++ b/src/main/groovy/asset/pipeline/react/CjsxAssetFile.groovy
@@ -1,0 +1,14 @@
+package asset.pipeline.react
+
+import asset.pipeline.AbstractAssetFile
+
+import java.util.regex.Pattern
+
+class CjsxAssetFile extends AbstractAssetFile {
+    static
+    final List<String> contentType = ['text/jsx', 'application/javascript', 'application/x-javascript', 'text/javascript']
+    static List<String> extensions = ['cjsx']
+    static String compiledExtension = 'js'
+    static processors = [CoffeeReactProcessor]
+    Pattern directivePattern = ~/(?m)^\/\/=(.*)/
+}

--- a/src/main/groovy/asset/pipeline/react/CoffeeReactProcessor.groovy
+++ b/src/main/groovy/asset/pipeline/react/CoffeeReactProcessor.groovy
@@ -1,0 +1,124 @@
+/*
+* Copyright 2014 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package asset.pipeline.react
+
+import asset.pipeline.AbstractProcessor
+import asset.pipeline.AssetCompiler
+import asset.pipeline.AssetFile
+import org.mozilla.javascript.Context
+import org.mozilla.javascript.Scriptable
+
+// Will attempt to use Node.JS cofee-react if it is available on the system path.
+// TODO: Implement support for Mozilla Rhino using coffee-react-transform
+class CoffeeReactProcessor extends AbstractProcessor {
+
+    static Boolean NODE_SUPPORTED
+    Scriptable globalScope
+    ClassLoader classLoader
+
+    CoffeeReactProcessor(AssetCompiler precompiler) {
+        super(precompiler)
+        if (!isNodeSupported()) {
+            try {
+                Context.exit()
+            } catch (IllegalStateException ignored) {
+            }
+            throw new Exception("Initialization failed - Node.js is required for coffee-react transformation.")
+        }
+    }
+
+    /**
+     * Processes an input string from a given AssetFile implementation of cjsx and converts it to coffeescript
+     * @param input String input cjsx script text to be converted to coffeescript
+     * @param AssetFile instance of the asset file from which this file came from. Not actually used currently for this implementation.
+     * @return String of compiled coffeescript
+     */
+    String process(String input, AssetFile assetFile) {
+        if (isNodeSupported()) {
+            return processWithNode(input, assetFile)
+        } else {
+            Context.exit()
+            throw new Exception("Initialization failed - Node.js is required for coffee-react transformation.")
+        }
+    }
+
+    /**
+     * Processes an input string of cjsx using node.js (Don't use directly)
+     * @param input String input cjsx script text to be converted to coffeescript
+     * @param AssetFile instance of the asset file from which this file came from.
+     * @return String of compiled coffeescript
+     */
+    def processWithNode(input, assetFile) {
+        def nodeProcess
+        def output = new StringBuilder()
+        def err = new StringBuilder()
+
+        try {
+            def command = "${isWindows() ? 'cmd /c ' : ''}cjsx -csp"
+            nodeProcess = command.execute()
+            nodeProcess.getOutputStream().write(input.bytes)
+            nodeProcess.getOutputStream().flush()
+            nodeProcess.getOutputStream().close()
+            nodeProcess.waitForProcessOutput(output, err)
+            if (err) {
+                throw new Exception(err.toString())
+            }
+            return output.toString()
+        } catch (Exception e) {
+            throw new Exception("""
+			Node.js transformation of cjsx to coffeescript failed.
+			$e
+			""")
+        }
+    }
+
+    /**
+     * Determins if this is on a windows platform or not (used for node system path)
+     * @return Boolean true if this is a windows machine
+     */
+    Boolean isWindows() {
+        String osName = System.getProperty("os.name");
+        return (osName != null && osName.contains("Windows"))
+    }
+
+    /**
+     * Determins if Node is supported on the System path
+     * @return Boolean true if Node.js is supported on the system path
+     */
+    Boolean isNodeSupported() {
+        if (NODE_SUPPORTED == null) {
+            def nodeProcess
+            def output = new StringBuilder()
+            def err = new StringBuilder()
+
+            try {
+                def command = "${isWindows() ? 'cmd /c ' : ''}cjsx -v"
+                nodeProcess = command.execute()
+                nodeProcess.waitForProcessOutput(output, err)
+                if (err) {
+                    NODE_SUPPORTED = false
+                } else {
+                    NODE_SUPPORTED = true
+                }
+            } catch (Exception ignored) {
+                NODE_SUPPORTED = false
+            }
+        }
+        return NODE_SUPPORTED
+    }
+
+}

--- a/src/test/groovy/asset/pipeline/react/CjsxAssetFileSpec.groovy
+++ b/src/test/groovy/asset/pipeline/react/CjsxAssetFileSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package asset.pipeline.react
+
+import spock.lang.Specification
+
+/**
+ * inspired by:
+ * @author David Estes
+ */
+class CjsxAssetFileSpec extends Specification {
+    void "should match directive patterns"() {
+        given:
+            def cjsxFile = new CjsxAssetFile()
+        when:
+            def matches = (line =~ cjsxFile.directivePattern)?.collect{ it[1].trim()} ?: []
+            def match = matches.size > 0 ? matches[0] : null
+        then:
+            directive == match
+        where:
+            line                    | directive
+            '//=require_self'       | 'require_self'
+            '//= require_self'      | 'require_self'
+            '//= require jquery'    | 'require jquery'
+            'Blank Section'         | null
+            '//= require_tree .'    | 'require_tree .'
+            '//= require_tree foo/' | 'require_tree foo/'
+    }
+
+}

--- a/src/test/groovy/asset/pipeline/react/CoffeeReactProcessorSpec.groovy
+++ b/src/test/groovy/asset/pipeline/react/CoffeeReactProcessorSpec.groovy
@@ -1,0 +1,53 @@
+/*
+* Copyright 2014 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package asset.pipeline.react
+
+import spock.lang.Ignore
+import spock.lang.Specification
+
+/**
+ * @author Tom Crossland
+ */
+class CoffeeReactProcessorSpec extends Specification {
+    @Ignore
+    // TODO: Rhino support currently not implemented
+    void "should compile cjsx into coffee using rhino"() {
+        given:
+        def cjsxScript = '-> <a />'
+        CoffeeReactProcessor.NODE_SUPPORTED = false
+        def processor = new CoffeeReactProcessor()
+
+        when:
+        def output = processor.process(cjsxScript, null)
+
+        then:
+        output.contains('React.createElement')
+    }
+
+    void "should compile cjsx into coffee using node"() {
+        given:
+        def cjsxScript = '-> <a />'
+        CoffeeReactProcessor.NODE_SUPPORTED = true
+        def processor = new CoffeeReactProcessor()
+
+        when:
+        def output = processor.process(cjsxScript, null)
+
+        then:
+        output.contains('React.createElement')
+    }
+}


### PR DESCRIPTION
The CSJX transformation currently only works with node.js and coffee-react installed. I expect it should be possible to get [coffee-react-transform](https://github.com/jsdf/coffee-react-transform) working with Rhino, but I haven't managed to.
